### PR TITLE
prevent link following

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,7 @@ const editor = {
 
   handler(e) {
     e.preventDefault();
+    e.stopPropagation();
 
     const el = getClickedElement(e);
     if (!el) return;


### PR DESCRIPTION
When translating text in links and buttons, these elements should not get the click event if the handler is active.