### PR TITLE
click event handler: prioritize over existing dom click events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,7 @@ const editor = {
     if (!el) return;
 
     const str = el.textContent || (el.text && el.text.innerText) || el.placeholder;
+    if (typeof str !== "string") return;
     const res = str.replace(/\n +/g, '').trim();
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,7 @@ const editor = {
   },
 
   on() {
-    document.body.addEventListener("click", this.handler);
+    document.body.addEventListener("click", this.handler, true);
     this.toggleUI(true);
     this.enabled = true;
   },


### PR DESCRIPTION
Even though there is `e.stopPropation()`, the event is handled after
existing app click events.

This means that action buttons, links, and all app installed click
events execute while the translation mode is on, which is very
intrusive when you only want to translate.