### PR TITLE
click handler: make ignorelocizeeditor elements clickable again

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,11 +65,12 @@ const editor = {
   },
 
   handler(e) {
+    const el = getClickedElement(e);
+    if (!el) return;
+
     e.preventDefault();
     e.stopPropagation();
 
-    const el = getClickedElement(e);
-    if (!el) return;
 
     const str = el.textContent || (el.text && el.text.innerText) || el.placeholder;
     if (typeof str !== "string") return;


### PR DESCRIPTION
Regression in previous commit: can't turn off the editor mode because
the click event was hijacked and not propagated.