### PR TITLE
options: add lngOverride

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,11 @@ locizeEditor.init({
   toggleKeyModifier: 'ctrlKey', // metaKey | altKey | shiftKey
   toggleKeyCode: 24, // x when pressing ctrl (e.which: document.addEventListener('keypress', (e) => console.warn(e.which, e));
 
-  // use lng in editor, eg. if running with lng=cimode (i18next, locize)
+  // use lng in editor taken from query string, eg. if running with lng=cimode (i18next, locize)
   lngOverrideQS: 'useLng',
+
+  // use lng in editor, eg. if running with lng=cimode (i18next, locize)
+  lngOverride: null,
 
   // default will open a iframe; setting to window will open a new window/tab instead
   mode: 'iframe' // 'window',

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const defaultOptions = {
   toggleKeyCode: 24,
   toggleKeyModifier: 'ctrlKey',
   lngOverrideQS: 'useLng',
+  lngOverride: null,
   autoOpen: true,
   onEditorSaved: (lng, ns) => {},
   mode: getQueryVariable('locizeMode') || 'iframe',
@@ -89,7 +90,7 @@ const editor = {
         message: 'searchForKey',
         projectId: this.i18next.options.backend.projectId,
         version: this.i18next.options.backend.version || 'latest',
-        lng: getQueryVariable(this.options.lngOverrideQS) || this.i18next.languages[0],
+        lng: getQueryVariable(this.options.lngOverrideQS) || this.options.lngOverride || this.i18next.languages[0],
         ns: getElementNamespace(res, el, this.i18next),
         token: removeNamespace(res, this.i18next)
       };


### PR DESCRIPTION
So one can programatically change the editor language in case of
cimode, without reloading the page.